### PR TITLE
add a get_selector method that returns everything after test-selector=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project.
 
 ## [Unreleased]
 
+## [0.1.1] - 2019-03-17
+
+### Added
+- `get_selector` method in the tests will now return the string of the
+    selection.
+
+
 ## [0.1.0] - 2019-03-17
 
 ### Added

--- a/lib/test_selector/version.rb
+++ b/lib/test_selector/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TestSelector
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
this is usefull when working with Capybara add_selector by which you can
find capybara selectors by entering the value of test-selector